### PR TITLE
Text placement: alignment and padding

### DIFF
--- a/lua/diagflow/init.lua
+++ b/lua/diagflow/init.lua
@@ -14,6 +14,8 @@ M.config = {
     gap_size = 1,
     scope = 'cursor', -- 'cursor', 'line'
     padding_top = 0,
+    padding_right = 0,
+    text_align = 'right', -- 'left', 'right'
 }
 
 local error = function (message)
@@ -47,6 +49,14 @@ function M.setup(user_config)
     end
     if type(config.padding_top) ~= 'number' then
         error('diagflow: Invalid type for "padding_top" config. Expected number, got ' .. type(config.padding_top))
+        return
+    end
+    if type(config.padding_right) ~= 'number' then
+        error('diagflow: Invalid type for "padding_right" config. Expected number, got ' .. type(config.padding_top))
+        return
+    end
+    if type(config.text_align) ~= 'string' or (config.text_align ~= 'left' and config.text_align ~= 'right') then
+        error('diagflow: Invalid value for "text_align" config. Expected "left" or "right", got ' .. config.text_align)
         return
     end
 

--- a/lua/diagflow/lazy.lua
+++ b/lua/diagflow/lazy.lua
@@ -94,15 +94,24 @@ function M.init(config)
         }
 
         local line_offset = 0
+        local win_width = vim.api.nvim_win_get_width(0) - vim.fn.getwininfo()[1].textoff - config.padding_right
         -- Render current_pos_diags
         for _, diag in ipairs(current_pos_diags) do
             local hl_group = severity[diag.severity]
             local message_lines = wrap_text(diag.message, config.max_width)
 
+            local max_width = 0
+            if config.text_align == 'left' then
+                for _, message in ipairs(message_lines) do
+                    max_width = math.max(max_width, #message)
+                end
+            end
+
             for _, message in ipairs(message_lines) do
+                local align = config.text_align == 'left' and max_width or #message
                 vim.api.nvim_buf_set_extmark(bufnr, ns, win_info.topline + line_offset + config.padding_top, 0, {
+                    virt_text_win_col = win_width - align,
                     virt_text = { { message, hl_group } },
-                    virt_text_pos = "right_align",
                     virt_text_hide = true,
                     strict = false
                 })


### PR DESCRIPTION
With this change we compute text placement ourselves. This allows us to add padding on the right side and configure the text alignment.

New settings:
- `padding_right`: number of columns we want to pad on the right side. Helpful if the terminal emulator is configured without padding.
- `text_align`: Currently supports `left` and `right` text alignment. 