### PR TITLE
feat(render): add diagnostic sign

### DIFF
--- a/lua/diagflow/init.lua
+++ b/lua/diagflow/init.lua
@@ -11,7 +11,7 @@ M.config = {
         info = "DiagnosticFloatingInfo",
         hint = "DiagnosticFloatingHint",
     },
-    show_sign = true,
+    show_sign = false,
     gap_size = 1,
     scope = 'cursor',  -- 'cursor', 'line'
     placement = 'top', -- top or inline

--- a/lua/diagflow/init.lua
+++ b/lua/diagflow/init.lua
@@ -11,6 +11,7 @@ M.config = {
         info = "DiagnosticFloatingInfo",
         hint = "DiagnosticFloatingHint",
     },
+    show_sign = true,
     gap_size = 1,
     scope = 'cursor',  -- 'cursor', 'line'
     placement = 'top', -- top or inline


### PR DESCRIPTION
Add a configuration option `show_sign` (defaults to true) to render the diagnostic sign before the diagnostic message