### PR TITLE
Add border to diagnostic

### DIFF
--- a/lua/diagflow/init.lua
+++ b/lua/diagflow/init.lua
@@ -34,7 +34,7 @@ M.config = {
         horizontal = "─",
         vertical = "│"
     },
-    show_border = false,
+    show_borders = false,
 }
 
 local error = function(message)
@@ -106,8 +106,8 @@ function M.setup(user_config)
         error('diagflow: Invalid value for "text_align" config. Expected "left" or "right", got ' .. config.text_align)
         return
     end
-    if type(config.show_border) ~= 'boolean' then
-        error('diagflow: Invalid value for "show_border" config. Expected true or false, got ' .. config.show_border)
+    if type(config.show_borders) ~= 'boolean' then
+        error('diagflow: Invalid value for "show_borders" config. Expected true or false, got ' .. config.show_border)
         return
     end
     if type(config.border_chars) ~= 'table' then

--- a/lua/diagflow/init.lua
+++ b/lua/diagflow/init.lua
@@ -25,7 +25,16 @@ M.config = {
     text_align = 'right',    -- 'left', 'right'
     update_event = { 'DiagnosticChanged', 'BufReadPost' },
     toggle_event = { },
-    render_event = { 'CursorMoved', 'DiagnosticChanged' }
+    render_event = { 'CursorMoved', 'DiagnosticChanged' },
+    border_chars = {
+        top_left = "┌",
+        top_right = "┐",
+        bottom_left = "└",
+        bottom_right = "┘",
+        horizontal = "─",
+        vertical = "│"
+    },
+    show_border = false,
 }
 
 local error = function(message)
@@ -97,7 +106,14 @@ function M.setup(user_config)
         error('diagflow: Invalid value for "text_align" config. Expected "left" or "right", got ' .. config.text_align)
         return
     end
-
+    if type(config.show_border) ~= 'boolean' then
+        error('diagflow: Invalid value for "show_border" config. Expected true or false, got ' .. config.show_border)
+        return
+    end
+    if type(config.border_chars) ~= 'table' then
+        error('diagflow: Invalid type for "border_chars" config. Expected table, got ' .. type(config.border_chars))
+        return
+    end
 
     diagflowlazy.init(M.config)
 end

--- a/lua/diagflow/lazy.lua
+++ b/lua/diagflow/lazy.lua
@@ -1,5 +1,22 @@
 local M = {}
 
+local function create_boxed_text(text_lines, padding, border_char)
+    local top_bottom_border = border_char .. string.rep(border_char, #text_lines[1] - 2) .. border_char
+    local boxed_lines = {top_bottom_border}
+    for _, line in ipairs(text_lines) do
+        table.insert(boxed_lines, border_char .. pad_text(line, padding) .. border_char)
+    end
+    table.insert(boxed_lines, top_bottom_border)
+    return boxed_lines
+end
+
+local function pad_text(text, padding)
+    local padded_text = string.rep(" ", padding) .. text .. string.rep(" ", padding)
+    return padded_text
+end
+
+
+
 local function len(T)
     local count = 0
     for _ in pairs(T) do count = count + 1 end
@@ -138,6 +155,7 @@ function M.init(config)
             local hl_group = severity[diag.severity]
             local sign = config.show_sign and signs[vim.diagnostic.severity[diag.severity]] .. " " or ""
             local message_lines = wrap_text(sign .. diag_message, config.max_width)
+            message_lines = create_boxed_text(message_lines, 1, "│")
 
             local max_width = 0
             if config.text_align == 'left' then

--- a/lua/diagflow/lazy.lua
+++ b/lua/diagflow/lazy.lua
@@ -162,7 +162,7 @@ function M.init(config)
             local hl_group = severity[diag.severity]
             local sign = config.show_sign and signs[vim.diagnostic.severity[diag.severity]] .. " " or ""
             local message_lines = wrap_text(sign .. diag_message, config.max_width)
-            message_lines = create_boxed_text(message_lines, config.show_border)
+            message_lines = create_boxed_text(message_lines, config.show_borders)
 
             local max_width = 0
             if config.text_align == 'left' then

--- a/lua/diagflow/lazy.lua
+++ b/lua/diagflow/lazy.lua
@@ -1,5 +1,10 @@
 local M = {}
 
+local function pad_text(text, padding)
+    local padded_text = string.rep(" ", padding) .. text .. string.rep(" ", padding)
+    return padded_text
+end
+
 local function create_boxed_text(text_lines, padding, border_char)
     local top_bottom_border = border_char .. string.rep(border_char, #text_lines[1] - 2) .. border_char
     local boxed_lines = {top_bottom_border}
@@ -9,13 +14,6 @@ local function create_boxed_text(text_lines, padding, border_char)
     table.insert(boxed_lines, top_bottom_border)
     return boxed_lines
 end
-
-local function pad_text(text, padding)
-    local padded_text = string.rep(" ", padding) .. text .. string.rep(" ", padding)
-    return padded_text
-end
-
-
 
 local function len(T)
     local count = 0

--- a/lua/diagflow/lazy.lua
+++ b/lua/diagflow/lazy.lua
@@ -1,17 +1,30 @@
 local M = {}
 
-local function pad_text(text, padding)
-    local padded_text = string.rep(" ", padding) .. text .. string.rep(" ", padding)
-    return padded_text
-end
+local border_chars = {
+    top_left = "┌",
+    top_right = "┐",
+    bottom_left = "└",
+    bottom_right = "┘",
+    horizontal = "─",
+    vertical = "│"
+}
 
-local function create_boxed_text(text_lines, padding, border_char)
-    local top_bottom_border = border_char .. string.rep(border_char, #text_lines[1] - 2) .. border_char
-    local boxed_lines = {top_bottom_border}
+local function create_boxed_text(text_lines)
+    local max_length = 0
     for _, line in ipairs(text_lines) do
-        table.insert(boxed_lines, border_char .. pad_text(line, padding) .. border_char)
+        max_length = math.max(max_length, #line)
     end
-    table.insert(boxed_lines, top_bottom_border)
+
+    local top_border = border_chars.top_left .. string.rep(border_chars.horizontal, max_length) .. border_chars.top_right
+    local bottom_border = border_chars.bottom_left .. string.rep(border_chars.horizontal, max_length) .. border_chars.bottom_right
+    local boxed_lines = {top_border}
+
+    for _, line in ipairs(text_lines) do
+        local padded_line = line .. string.rep(" ", max_length - #line)
+        table.insert(boxed_lines, border_chars.vertical .. padded_line .. border_chars.vertical)
+    end
+
+    table.insert(boxed_lines, bottom_border)
     return boxed_lines
 end
 

--- a/lua/diagflow/lazy.lua
+++ b/lua/diagflow/lazy.lua
@@ -1,15 +1,11 @@
 local M = {}
 
-local border_chars = {
-    top_left = "┌",
-    top_right = "┐",
-    bottom_left = "└",
-    bottom_right = "┘",
-    horizontal = "─",
-    vertical = "│"
-}
+local function create_boxed_text(text_lines, add_boxed_text)
+    if #text_lines == 0 or not add_boxed_text then
+        return text_lines
+    end
+    local border_chars = M.config.border_chars
 
-local function create_boxed_text(text_lines)
     local max_length = 0
     for _, line in ipairs(text_lines) do
         max_length = math.max(max_length, #line)
@@ -166,7 +162,7 @@ function M.init(config)
             local hl_group = severity[diag.severity]
             local sign = config.show_sign and signs[vim.diagnostic.severity[diag.severity]] .. " " or ""
             local message_lines = wrap_text(sign .. diag_message, config.max_width)
-            message_lines = create_boxed_text(message_lines, 1, "│")
+            message_lines = create_boxed_text(message_lines, config.show_border)
 
             local max_width = 0
             if config.text_align == 'left' then

--- a/readme.md
+++ b/readme.md
@@ -66,7 +66,16 @@ require('diagflow').setup({
     update_event = { 'DiagnosticChanged', 'BufReadPost' }, -- the event that updates the diagnostics cache
     toggle_event = { }, -- if InsertEnter, can toggle the diagnostics on inserts
     show_sign = false, -- set to true if you want to render the diagnostic sign before the diagnostic message
-    render_event = { 'DiagnosticChanged', 'CursorMoved' }
+    render_event = { 'DiagnosticChanged', 'CursorMoved' },
+    border_chars = {
+      top_left = "┌",
+      top_right = "┐",
+      bottom_left = "└",
+      bottom_right = "┘",
+      horizontal = "─",
+      vertical = "│"
+    },
+    show_borders = false,
 })
 ```
 
@@ -151,6 +160,17 @@ You can set a diagnostic message by supplying the `format` option.
     enable = function()
       return vim.bo.filetype ~= "lazy"
     end,
+  },
+}
+```
+
+7. How do I show borders?
+
+```lua
+{
+  'dgagn/diagflow.nvim',
+  opts = {
+    show_borders = true,
   },
 }
 ```


### PR DESCRIPTION
Closes #37, Adds new config like :
```
    -- ...
    border_chars = {
        top_left = "┌",
        top_right = "┐",
        bottom_left = "└",
        bottom_right = "┘",
        horizontal = "─",
        vertical = "│"
    },
    show_borders = false,
    -- ...
``` 

It defaults to false, since I don't use borders and don't want to break existing configs.