### PR TITLE
fix: wrap diagnostic text in respect to lines

### DIFF
--- a/lua/diagflow/lazy.lua
+++ b/lua/diagflow/lazy.lua
@@ -228,12 +228,6 @@ function M.init(config)
     end
 
     group = vim.api.nvim_create_augroup('RenderDiagnostics', { clear = true })
-    vim.api.nvim_create_autocmd(config.render_event, {
-        callback = render_diagnostics,
-        pattern = "*",
-        group = group
-    })
-
     if len(config.toggle_event) > 0 then
         vim.api.nvim_create_autocmd(config.toggle_event, {
             callback = toggle,
@@ -243,6 +237,12 @@ function M.init(config)
     end
     vim.api.nvim_create_autocmd(config.update_event, {
         callback = update_cached_diagnostic,
+        pattern = "*",
+        group = group
+    })
+
+    vim.api.nvim_create_autocmd(config.render_event, {
+        callback = render_diagnostics,
         pattern = "*",
         group = group
     })

--- a/lua/diagflow/lazy.lua
+++ b/lua/diagflow/lazy.lua
@@ -32,18 +32,25 @@ end
 
 local function wrap_text(text, max_width)
     local lines = {}
-    local line = ""
 
-    for word in text:gmatch("%S+") do
-        if #line + #word + 1 > max_width then
-            table.insert(lines, line)
-            line = word
-        else
-            line = line ~= "" and line .. " " .. word or word
+    for line in text:gmatch("([^\n]*)\n?") do
+        local wrapped_line = ""
+        for word in line:gmatch("%S+") do
+            if #wrapped_line + #word + 1 > max_width then
+                local trimmed_line = vim.trim(wrapped_line)
+                if trimmed_line ~= "" then
+                    table.insert(lines, trimmed_line)
+                end
+                wrapped_line = word
+            else
+                wrapped_line = wrapped_line ~= "" and wrapped_line .. " " .. word or word
+            end
+        end
+        local trimmed_line = vim.trim(wrapped_line)
+        if trimmed_line ~= "" then
+            table.insert(lines, trimmed_line)
         end
     end
-
-    table.insert(lines, line)
 
     return lines
 end


### PR DESCRIPTION
In order to show diagnostic text lines as they're originally constructed, we can wrap text in respect to diagnostic lines. Also trimming is added for lines rendered.

This change is in-line to how `helix` renders diagnostics: https://github.com/helix-editor/helix/blob/d5e6749fa250f3a7be75c81c7b0611e3c3221d63/helix-term/src/ui/editor.rs#L698-L721

## Before

<img width="426" alt="image" src="https://github.com/dgagn/diagflow.nvim/assets/6879030/547bdddd-3b34-4453-92fe-cfe972f3fb4d">

## After

<img width="344" alt="image" src="https://github.com/dgagn/diagflow.nvim/assets/6879030/6d21e494-1ebc-44e7-bdc9-a1d04f8d0599">

### Note 

The PR also adds a fix for rendering diagnostics after cache is being updated, as nvim execute [autocmds](https://neovim.io/doc/user/autocmd.html#autocmd-define) in the order in which they are defined:

> Nvim always adds {cmd} after existing autocommands so they execute in the order in which they were defined.
			
Defining `autocmd` for rendering after update `autocmd` fixes the issue of a diagnostic not being visible after it immediately  shows up.
