### PR TITLE
Accommodate multi-byte characters

### DIFF
--- a/lua/diagflow/lazy.lua
+++ b/lua/diagflow/lazy.lua
@@ -8,7 +8,8 @@ local function create_boxed_text(text_lines, add_boxed_text)
 
     local max_length = 0
     for _, line in ipairs(text_lines) do
-        max_length = math.max(max_length, #line)
+        local line_length = vim.api.nvim_strwidth(line)
+        max_length = math.max(max_length, line_length)
     end
 
     local top_border = border_chars.top_left .. string.rep(border_chars.horizontal, max_length) .. border_chars.top_right
@@ -16,7 +17,8 @@ local function create_boxed_text(text_lines, add_boxed_text)
     local boxed_lines = {top_border}
 
     for _, line in ipairs(text_lines) do
-        local padded_line = line .. string.rep(" ", max_length - #line)
+        local line_length = vim.api.nvim_strwidth(line)
+        local padded_line = line .. string.rep(" ", max_length - line_length)
         table.insert(boxed_lines, border_chars.vertical .. padded_line .. border_chars.vertical)
     end
 
@@ -33,9 +35,11 @@ end
 local function wrap_text(text, max_width)
     local lines = {}
     local line = ""
+    local line_length = vim.api.nvim_strwidth(line)
 
     for word in text:gmatch("%S+") do
-        if #line + #word + 1 > max_width then
+        local word_length = vim.api.nvim_strwidth(word)
+        if line_length + word_length + 1 > max_width then
             table.insert(lines, line)
             line = word
         else


### PR DESCRIPTION
I'm trying out the NvChad distribution that uses Nerd Fonts for diagnostic signs.

See: https://github.com/NvChad/ui/blob/v2.0/lua/nvchad/lsp.lua#L1

When enabling `show_sign` and `show_borders`, each line with a sign does not have an aligned border:

![image](https://github.com/dgagn/diagflow.nvim/assets/1748909/a9c89091-5493-47b5-858c-5f8da7707733)

This is because `#line` counts this line as **51** characters instead of **49**, causing the top and bottom borders to be too long.

Lua's string lengths count bytes, not code points / display characters. Neovim offers an api [nvim_strwidth](https://neovim.io/doc/user/api.html#nvim_strwidth()) to get the number of display cells occupied by text.

After this change:

![image](https://github.com/dgagn/diagflow.nvim/assets/1748909/2c58a8bd-0850-480c-93f8-8e12baa5480b)
