### PR TITLE
fix: adapt to Nvim 0.11 deprecations

### DIFF
--- a/lua/diagflow/lazy.lua
+++ b/lua/diagflow/lazy.lua
@@ -129,11 +129,11 @@ function M.init(config)
 
         local is_diagnostics_disabled = false
 
-		if vim.fn.has("nvim-0.11") == 1 then
-			is_diagnostics_disabled = vim.diagnostic.is_enabled ~= nil and not vim.diagnostic.is_enabled()
-		else
-			is_diagnostics_disabled = vim.diagnostic.is_disabled ~= nil and vim.diagnostic.is_disabled(0)
-		end
+        if vim.fn.has("nvim-0.11") == 1 then
+            is_diagnostics_disabled = vim.diagnostic.is_enabled ~= nil and not vim.diagnostic.is_enabled()
+        else
+            is_diagnostics_disabled = vim.diagnostic.is_disabled ~= nil and vim.diagnostic.is_disabled(0)
+        end
 
         if is_diagnostics_disabled then
             return

--- a/lua/diagflow/lazy.lua
+++ b/lua/diagflow/lazy.lua
@@ -127,7 +127,15 @@ function M.init(config)
             return
         end
 
-        if vim.diagnostic.is_disabled ~= nil and vim.diagnostic.is_disabled(0) then
+        local is_diagnostics_disabled = false
+
+		if vim.fn.has("nvim-0.11") == 1 then
+			is_diagnostics_disabled = vim.diagnostic.is_enabled ~= nil and not vim.diagnostic.is_enabled()
+		else
+			is_diagnostics_disabled = vim.diagnostic.is_disabled ~= nil and vim.diagnostic.is_disabled(0)
+		end
+
+        if is_diagnostics_disabled then
             return
         end
 


### PR DESCRIPTION
vim.diagnostic.is_disabled() is deprecated. See: https://neovim.io/doc/user/deprecated.html#vim.diagnostic.is_disabled()

With this PR we adapt to this deprecation while not breaking backward compatibility.
