### PR TITLE
fix: render only current buffer's diagnostics

### DIFF
--- a/lua/diagflow/lazy.lua
+++ b/lua/diagflow/lazy.lua
@@ -147,9 +147,11 @@ function M.init(config)
 
         local current_pos_diags = {}
         for _, diag in ipairs(diags) do
-            if config.scope == 'line' and diag.lnum == line or
-                config.scope == 'cursor' and diag.lnum == line and diag.col <= col and (diag.end_col or diag.col) >= col then
-                table.insert(current_pos_diags, diag)
+            if win_info.bufnr ==  diag.bufnr then
+                if config.scope == 'line' and diag.lnum == line or
+                    config.scope == 'cursor' and diag.lnum == line and diag.col <= col and (diag.end_col or diag.col) >= col then
+                    table.insert(current_pos_diags, diag)
+                end
             end
         end
 


### PR DESCRIPTION
Currently, the buffer number is not checked, leading to rendering diagnostics of other buffers in same cursor location (e.g. same "line" diagnostics in a vsplit)