### PR TITLE
feat: show diagnostics on multiline diags

### DIFF
--- a/lua/diagflow/lazy.lua
+++ b/lua/diagflow/lazy.lua
@@ -155,8 +155,23 @@ function M.init(config)
 
         local current_pos_diags = {}
         for _, diag in ipairs(diags) do
-            if config.scope == 'line' and diag.lnum == line or
-                config.scope == 'cursor' and diag.lnum == line and diag.col <= col and (diag.end_col or diag.col) >= col then
+            local should_insert = false
+            local in_line = diag.lnum <= line and line <= (diag.end_lnum or diag.lnum)
+            if config.scope == 'line' then
+                should_insert = in_line
+            elseif config.scope == 'cursor' then
+                if diag.end_col and diag.end_lnum then
+                    should_insert = in_line and
+                        ((diag.lnum == line and diag.col <= col)               -- On the first line, should be after the col
+                            or (diag.lnum < line and line < diag.end_lnum)     -- Between lines, we always show it
+                            or (diag.end_lnum == line and col <= diag.end_col) -- On the last line, only before the end
+                        )
+                else
+                    should_insert = diag.lnum == line and (diag.col <= col and (diag.end_col or diag.col) >= col)
+                end
+            end
+
+            if should_insert then
                 table.insert(current_pos_diags, diag)
             end
         end


### PR DESCRIPTION
Currently if a diagnostic spans multiple lines, the current implementation doesn't show anything past the first line. This changes this behavior.

This is set as the default, but happy to but that behind a flag if needed.

The one case that is problematic (even now) is if `end_col` doesn't exist (as it seems it can be, same for `end_lnum`) then the last check `diag.col <= col and (diag.end_col or diag.col) >= col)` will only be true on the actual `col` and nowhere else since `(diag.col <= col and diag.col >= col)` is equivalent to the two being equal. I don't know how often this happens in practice. This is why I've kept the old behavior if we don't have `diag.end_col and diag.end_lnum`, though personally I would show it for the whole line if we don't have a `end_col`.
